### PR TITLE
スクロリファイのエラー解消

### DIFF
--- a/top.html
+++ b/top.html
@@ -813,12 +813,12 @@
       });
     </script>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollify/1.0.19/jquery.scrollify.min.js"></script>
     <script
       src="https://code.jquery.com/jquery-3.6.0.min.js"
       integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
       crossorigin="anonymous"
     ></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollify/1.0.19/jquery.scrollify.min.js"></script>
 
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/scrollify/1.0.21/jquery.scrollify.min.js"


### PR DESCRIPTION
JQueryを読み込む位置がスクロリファイより下なため、ブラウザエラーが一件出ていた件を解消
（ただ位置を変えただけです）